### PR TITLE
Version bump panasonic_viera to 0.3.6

### DIFF
--- a/homeassistant/components/panasonic_viera/manifest.json
+++ b/homeassistant/components/panasonic_viera/manifest.json
@@ -2,7 +2,7 @@
   "domain": "panasonic_viera",
   "name": "Panasonic Viera",
   "documentation": "https://www.home-assistant.io/integrations/panasonic_viera",
-  "requirements": ["panasonic_viera==0.3.5"],
+  "requirements": ["panasonic_viera==0.3.6"],
   "codeowners": ["@joogps"],
   "config_flow": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1045,7 +1045,7 @@ paho-mqtt==1.5.0
 panacotta==0.1
 
 # homeassistant.components.panasonic_viera
-panasonic_viera==0.3.5
+panasonic_viera==0.3.6
 
 # homeassistant.components.pcal9535a
 pcal9535a==0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -489,7 +489,7 @@ ovoenergy==1.1.7
 paho-mqtt==1.5.0
 
 # homeassistant.components.panasonic_viera
-panasonic_viera==0.3.5
+panasonic_viera==0.3.6
 
 # homeassistant.components.dunehd
 pdunehd==1.3.2


### PR DESCRIPTION
This version fixes the issue of mishandling an error when requesting a session id.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Using version 0.3.5 of the `panasonic_viera` library can lead to the following error:

```
Log Details (ERROR)
Logger: homeassistant.components.panasonic_viera
Source: components/panasonic_viera/__init__.py:148 
Integration: Panasonic Viera (documentation, issues) 
First occurred: 9:53:08 AM (1 occurrences) 
Last logged: 9:53:08 AM

An unknown error occurred: local variable 'res' referenced before assignment
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/panasonic_viera/__init__.py", line 148, in async_create_remote_control
    self._control = await self._hass.async_add_executor_job(
  File "/usr/local/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.8/site-packages/panasonic_viera/__init__.py", line 164, in __init__
    self._request_session_id()
  File "/usr/local/lib/python3.8/site-packages/panasonic_viera/__init__.py", line 412, in _request_session_id
    root = ET.fromstring(res)
UnboundLocalError: local variable 'res' referenced before assignment
```

This is because of [error handling logic leaving scope under certain conditions](https://github.com/florianholzapfel/panasonic-viera/blob/0.3.5/panasonic_viera/__init__.py#L404), resuming only to access a variable uninitialized due to the error. Version [0.3.6](https://github.com/florianholzapfel/panasonic-viera/blob/0.3.6/panasonic_viera/__init__.py#L416) resolves this issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
This is a previously unreported issue that I have come across and taking the initiative to address.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
